### PR TITLE
fix: Can't open some files that contains cjk characters in its name

### DIFF
--- a/denops/@ddu-sources/git_status.ts
+++ b/denops/@ddu-sources/git_status.ts
@@ -64,12 +64,13 @@ export class Source extends BaseSource<Params> {
           "status",
           "-uall",
           "--porcelain=v1",
+          "-z",
         ])
           .then((output) =>
-            output.split("\n").filter((line) => line.length !== 0)
+            output.split("\0").filter((line) => line.length !== 0)
           );
         controller.enqueue(status.map((line) => {
-          const displayPath = line.replace(/^..."?/, "").replace(/"?$/, "");
+          const displayPath = line.replace(/^.../, "");
           return {
             word: displayPath,
             action: {


### PR DESCRIPTION
## Problem

 file kind can't open some files that contains `unusual characters` in their names. Because `item.action.path` value of items that be gathered by git_status source is unavailable.

## Solution

 Use `-z` flag to be disable quoting features of git-status.