### PR TITLE
fix: Prevent displaying renamed file names

### DIFF
--- a/denops/@ddu-sources/git_status.ts
+++ b/denops/@ddu-sources/git_status.ts
@@ -73,9 +73,19 @@ export class Source extends BaseSource<Params> {
           "--porcelain=v1",
           "-z",
         ])
-          .then((output) =>
-            output.split("\0").filter((line) => line.length !== 0)
-          );
+          .then((output) => {
+            const lines = output.split("\0");
+            const filteredLines: string[] = [];
+            for (let i = 0; i < lines.length; i++) {
+              if (lines[i].length !== 0) {
+                filteredLines.push(lines[i]);
+                if (lines[i].startsWith("R")) {
+                  i++;
+                }
+              }
+            }
+            return filteredLines;
+          });
         controller.enqueue(status.map((line) => {
           const pathLine = line.slice(3);
           return {


### PR DESCRIPTION
## Problem
When renaming a file and staging it, the original file name is displayed with incorrect highlighting.
![rename-and-staged](https://github.com/kuuote/ddu-source-git_status/assets/61235023/92def6c6-d4e1-40b7-a957-7ace031aec56)

## Solution
Modify the display to avoid showing the line immediately after the line with status "R".



Since I'm still learning, please feel free to point out any mistakes or errors in my pull request. Your feedback is greatly appreciated.